### PR TITLE
(#1169797) Replace Fixnum type removed in Ruby 3+ with Integer

### DIFF
--- a/lib/intouch/support/issue_formatable.rb
+++ b/lib/intouch/support/issue_formatable.rb
@@ -93,7 +93,7 @@ module Intouch
               else
                 I18n.t(('field_' + field).to_sym)
               end
-            elsif field.is_a? Fixnum
+            elsif field.is_a? Integer
               CustomField.find(field).try(:name)
             end
           end.join(', ')


### PR DESCRIPTION
https://factory.southbridge.io/issues/1169797